### PR TITLE
fix: Delay CSS generation till after hugo_stats.json is availabe

### DIFF
--- a/layouts/partials/head/libsass.html
+++ b/layouts/partials/head/libsass.html
@@ -4,6 +4,6 @@
   {{ $css = resources.Get . | toCSS $options | resources.Fingerprint "sha512" -}}
 {{ else -}}
   {{ $options := (dict "targetPath" "main.css" "transpiler" "libsass" "outputStyle" "compressed" "includePaths" (slice "node_modules")) -}}
-  {{ $css = resources.Get . | toCSS $options | postCSS (dict "config" "config/postcss.config.js") | resources.Fingerprint "sha512" -}}
+  {{ $css = resources.Get . | toCSS $options | postCSS (dict "config" "config/postcss.config.js") |  resources.Fingerprint "sha512" | resources.PostProcess -}}
 {{ end -}}
-<link rel="stylesheet" href="{{ $css.Permalink | relURL }}" integrity="{{ $css.Data.Integrity }}" crossorigin="anonymous">
+<link rel="stylesheet" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}" crossorigin="anonymous">


### PR DESCRIPTION


## Summary

If CSS generation happens before the hugo_stats.json is built, important CSS class will be missing from the generation.  This can be avoided by using `resources.PostProcess` in the pipeline generating the CSS output.

Also switch to using RelPermalink, as otherwise the url will be incorrect with the change.

## Basic example

This should cause no change to the built site, beyond it being correct if CSS classes are being stripped.

## Motivation

This fixes a bug when generating our site.

## Checks

- [ ] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
