### PR TITLE
Google Quicklink optimization/fixes

### DIFF
--- a/.changeset/clever-trainers-sip.md
+++ b/.changeset/clever-trainers-sip.md
@@ -1,0 +1,5 @@
+---
+"@hyas/core": patch
+---
+
+Google Quicklink optimization/fixes

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -1,6 +1,13 @@
 // https://github.com/GoogleChromeLabs/quicklink
 import { listen } from 'quicklink/dist/quicklink.mjs';
-listen();
+listen({
+    ignores: [
+        /\/api\/?/,
+        uri => uri.includes('.zip'),
+        (uri, elem) => elem.hasAttribute('noprefetch'),
+        (uri, elem) => elem.hash && elem.pathname === window.location.pathname,
+    ]
+});
 
 // https://github.com/aFarkas/lazysizes/tree/gh-pages/plugins/native-loading
 import lazySizes from 'lazysizes';


### PR DESCRIPTION
Adds ignores to the quick link prefetch so that it doesn't prefetch anchor links from the same page, api links, zip files and allows for a noprefetch attribute (useful for people that use lightboxes for example).

## Summary

I found out that I focused too much on the Lighthouse scores. Those were perfect, but I noticed a big increase in bandwidth usage after we've added several pages. So I decided to check the network traffic and found several issues that were my fault in combination with the current Quicklink implementation.

### Issues / example / motivation:

- We have some very obscure machines with hard to find software. I therefore added some larger downloads to the website, but I noticed that those download were also prefetched. Which means that plugins of 100mb that a user might not want was still fetched.
<img width="1385" alt="Scherm­afbeelding 2024-08-11 om 02 52 16" src="https://github.com/user-attachments/assets/9deae857-9231-470e-80df-d74f7159b9a8">

- We can argue if I should design my page like this ;) but some of my pages feature quick anchor links to the same page. This meant that the same page was prefetched several times (extreme for content heavy pages). 
<img width="1425" alt="Scherm­afbeelding 2024-08-11 om 02 51 15" src="https://github.com/user-attachments/assets/21afb34b-e219-4942-85e3-02a463fcdb8f">

- I'm using a lightbox which uses an <a> element that refers to the full resolution image. This means that the full resolution images were prefetched even if the lightbox wasn't opened. When the lightbox was opened, the lightbox plugin would download the image again. This is inefficient so I added the option for a 'noprefetch' attribute that was implemented in my lightbox shortcode. (Fun fact: In my photo swipe lightbox implementation was a link to the full resolution png image. The lightbox actually loaded the correct file, because the lightbox attribute was of a higher priority than the data-src url. However, due to the prefetch, for the past few months all the large images have been downloaded and people didn't even see them in the lightbox haha). 

## Basic example

New function:
`listen({
    ignores: [
        /\/api\/?/,
        uri => uri.includes('.zip'),
        (uri, elem) => elem.hasAttribute('noprefetch'),
        (uri, elem) => elem.hash && elem.pathname === window.location.pathname,
    ]
});`

This check for api links, zip files (perhaps we should do something with .pdf's as well?), allow for noprefetch attributes and check for links with hashes that are on the same path (prevent blocking all anchor links). 

## Motivation

Should make the websites faster / prevent unnecessary traffic. 

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x ] Passes `npm run test`
